### PR TITLE
feat: ability to send tracking event asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If you specified the `attr-tracking` attribute on the script tag, then all `butt
 available:
   - `swa-event-category` - Optional. The category of the event that can be used to group events.
   - `swa-event-data` - Optional. The data of the event. Defaults to 1.
+  - `swa-event-async` - Optional. If present, the event will be sent asynchronously
+    with no guarantee of delivery but a better chance of not being canceled if page is unloaded right after.
 
 ```html
 <button swa-event="download">Download</button>
@@ -64,7 +66,7 @@ available:
 
 <button swa-event="buy" swa-event-category="clicks" swa-event-data="99">Buy now</button>
 
-<a swa-event="click" swa-event-category="link" swa-event-data="2">Click me</a>
+<a swa-event="click" swa-event-category="link" swa-event-data="2" swa-event-async>Click me</a>
 ```
 
 ##### Manual tracking

--- a/package/src/cdn/client-script.ts
+++ b/package/src/cdn/client-script.ts
@@ -79,11 +79,13 @@ import * as swaClient from "../";
           const trackCategory = eventTarget.getAttribute('swa-event-category') || undefined;
           const trackData = eventTarget.getAttribute('swa-event-data') || undefined;
           const trackDataNumber = trackData ? Number(trackData) : undefined;
+          const asyncAttr = eventTarget.getAttribute('swa-event-async');
+          const async = (asyncAttr !== null && asyncAttr.toLowerCase() !== "false") || false;
 
           // Have to use on the window object because the local defined swaClient is out of scope, it seems.
           //@ts-ignore
           const globalSwaClient = window.swa as typeof swaClient;
-          globalSwaClient.v1.analyticsTrack(trackEvent, trackDataNumber, trackCategory);
+          globalSwaClient.v1.analyticsTrack(trackEvent, trackDataNumber, trackCategory, async);
         }
       });
     });

--- a/package/src/cdn/client-script.ts
+++ b/package/src/cdn/client-script.ts
@@ -80,12 +80,12 @@ import * as swaClient from "../";
           const trackData = eventTarget.getAttribute('swa-event-data') || undefined;
           const trackDataNumber = trackData ? Number(trackData) : undefined;
           const asyncAttr = eventTarget.getAttribute('swa-event-async');
-          const async = (asyncAttr !== null && asyncAttr.toLowerCase() !== "false") || false;
+          const isAsync = (asyncAttr !== null && asyncAttr.toLowerCase() !== "false") || false;
 
           // Have to use on the window object because the local defined swaClient is out of scope, it seems.
           //@ts-ignore
           const globalSwaClient = window.swa as typeof swaClient;
-          globalSwaClient.v1.analyticsTrack(trackEvent, trackDataNumber, trackCategory, async);
+          globalSwaClient.v1.analyticsTrack(trackEvent, trackDataNumber, trackCategory, isAsync);
         }
       });
     });

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -243,9 +243,9 @@ export namespace v1
    * @param event The event name
    * @param data If omitted, defaults to 1
    * @param category Optional
-   * @param async Make a request with no guarantee of delivery but a better chance of not being canceled if page is unloaded right after. Defaults to false.
+   * @param isAsync Make a request with no guarantee of delivery but a better chance of not being canceled if page is unloaded right after. Defaults to false.
    */
-  export function analyticsTrack(event: string, data?: number, category?: string, async: boolean = false)
+  export function analyticsTrack(event: string, data?: number, category?: string, isAsync: boolean = false)
   {
     if(!global.inBrowser)
       return;
@@ -276,7 +276,7 @@ export namespace v1
       querystring: getCleanQueryString(params)
     };
 
-    sendRequest(global.apiUrl+pathTrackEvent, JSON.stringify(trackedEvent), async);
+    sendRequest(global.apiUrl+pathTrackEvent, JSON.stringify(trackedEvent), isAsync);
   }
 
 }

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -240,12 +240,12 @@ export namespace v1
 
   /**
    * Call on every event you want to track, like button clicks etc
-   * @param inBrowser
    * @param event The event name
    * @param data If omitted, defaults to 1
    * @param category Optional
+   * @param async Make a request with no guarantee of delivery but a better chance of not being canceled if page is unloaded right after. Defaults to false.
    */
-  export function analyticsTrack(event: string, data?: number, category?: string)
+  export function analyticsTrack(event: string, data?: number, category?: string, async: boolean = false)
   {
     if(!global.inBrowser)
       return;
@@ -276,7 +276,7 @@ export namespace v1
       querystring: getCleanQueryString(params)
     };
 
-    sendRequest(global.apiUrl+pathTrackEvent, JSON.stringify(trackedEvent));
+    sendRequest(global.apiUrl+pathTrackEvent, JSON.stringify(trackedEvent), async);
   }
 
 }


### PR DESCRIPTION
If the tracking event is attached to an external link, the page is unloaded right after click.
In such case the fetch tracking request may get canceled.

This exposes "bestEffort" flag to send tracking request using beacon (Firefox) / keepalive (Chrome and others).

Closes #19 